### PR TITLE
Fetch the plugin config from the proper key in Brunch config

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -15,7 +15,7 @@ function BrowserSync(config) {
         };
 
     if(config && config.plugins && config.plugins.browserSync) {
-        cfg = config;
+        cfg = config.plugins.browserSync;
     } else {
         cfg = {};
     }


### PR DESCRIPTION
Otherwise it totally screws up the perceived config and has the bowels of BrowserSync blow up.
OTOH 1.5.9 works the same as 1.5.2 WRT this plugin, so didn't change `package.json`
