### PR TITLE
Update browser-sync to 2.0.1

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -93,18 +93,21 @@ BrowserSync.prototype.compile = function browserSyncCompile(params, callback) {
         return callback(null, params);
     }
 
-    var that = this;
+    var self = this;
     this.onServerSnippet = function browserSyncOnServerSnippet() {
         var injectedJS = [
             '(function(/* BrowserSync-Brunch */) {',
-            '  var url = "//" + location.hostname + ":' + that.server.options.port +
-                '/browser-sync/browser-sync-client.' + that.server.version + '.js";',
+            '  var url = "//" + location.hostname + ":PORT' +
+                '/browser-sync/browser-sync-client.VERSION.js";',
             '  var bs = document.createElement("script");',
             '  bs.type = "text/javascript"; bs.async = true; bs.src = url;',
             '  var s = document.getElementsByTagName("script")[0];',
             '  s.parentNode.insertBefore(bs, s);',
             '})();'
-        ].join("\n");
+        ]
+        .join("\n")
+        .replace(/PORT/g, self.server.options.getIn(['port']))
+        .replace(/VERSION/g, self.server.options.getIn(['version']));
 
         params.data = injectedJS;
         callback(null, params);

--- a/package.json
+++ b/package.json
@@ -3,9 +3,18 @@
   "version": "0.0.8",
   "description": "Adds browser-sync support to brunch for automatic browser reloading and much more",
   "author": "Olivier Combe <olivier.combe@gmail.com>",
-  "contributors": ["Christophe Porteneuve <tdd@tddsworld.com>"],
+  "contributors": [
+    "Christophe Porteneuve <tdd@tddsworld.com>"
+  ],
   "homepage": "https://github.com/ocombe/browser-sync-brunch",
-  "keywords": ["brunchplugin", "auto-reload", "auto reload", "browser-sync", "browser sync", "browsersync"],
+  "keywords": [
+    "brunchplugin",
+    "auto-reload",
+    "auto reload",
+    "browser-sync",
+    "browser sync",
+    "browsersync"
+  ],
   "repository": {
     "type": "git",
     "url": "git@github.com:ocombe/browser-sync-brunch.git"
@@ -13,7 +22,7 @@
   "main": "./lib/index",
   "scripts": {},
   "dependencies": {
-    "browser-sync": "~1.6.3",
+    "browser-sync": "^2.0.1",
     "extend": "~1.3.0"
   },
   "devDependencies": {}


### PR DESCRIPTION
This commit upgrade browser-sync to ~2.0 version:
* update package.json file
* update `browserSyncOnServerSnippet` to use the new browser way to
access immutable internal data