### PR TITLE
Make the config `enabled: false` to work properly

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -22,7 +22,7 @@ function BrowserSync(config) {
         cfg = {};
     }
     if (config && config.persistent) {
-        self.enabled = cfg.enabled ? cfg.enabled : true;
+        self.enabled = (cfg.enabled == null) ? true : cfg.enabled;
     }
 
     if (self.enabled && !browserSync.active) {


### PR DESCRIPTION
This PR make it possible to have `enabled: false` in brunch config file, to deactivate browser-sync.
It can be really convenient to temporarily disable browser-sync in order for debugging purposes.