### PR TITLE
Increase BrowserSync version to 2.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "main": "./lib/index",
   "scripts": {},
   "dependencies": {
-    "browser-sync": "^2.3.1",
+    "browser-sync": "^2.6.0",
     "extend": "~1.3.0"
   },
   "devDependencies": {}


### PR DESCRIPTION
Increase BrowserSync dependency version to 2.6.0 to allow use of watch event custom callbacks, as documented here : https://browsersync.io/docs/options/#option-files